### PR TITLE
Fixed sanity.sh

### DIFF
--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -4,9 +4,9 @@ t3ize_sh="${0%/*}/../lib/t3ize.sh"
 source "$t3ize_sh"
 
 yak "sanity check initiated"
-apt_install "figlet toilet cowsay fortune lolcat"
-apt_install "jq curl git vim tmux htop"
-apt_install "pv"
+sudo apt install "figlet toilet cowsay fortune lolcat"
+sudo apt install "jq curl git vim tmux htop"
+sudo apt install "pv"
 figlet "T3X" | lolcat
 
 echo -n "sanity check success"; sleep 1; echo " . . . we hope" | pv -qL 5 | lolcat


### PR DESCRIPTION
Fixed sanity.sh to use "sudo apt install" instead of apt_install. (Wasn't Working)