### PR TITLE
Raspberry Pi Network Scripts

### DIFF
--- a/tools/pi/scripts/AP.sh
+++ b/tools/pi/scripts/AP.sh
@@ -1,8 +1,11 @@
-!/usr/bin/bash
-#source $(t3x -T)
+#!/usr/bin/bash
+source $(t3x -T)
 
 #var set to AP SSID
 AP="RaspAP"
+
+connection_status=$(nmcli -t -f NAME connection show --active | grep "^$AP")
+
 
 AP_up() {
 	nmcli connection up "$AP"
@@ -12,9 +15,30 @@ AP_up() {
 AP_down() {
 	nmcli connection down "$AP"
 	echo "Access Point '$AP' has been turned off"
-
 }
 
+#check if AP has ever been connected to this dev
+first_con() {
+	nmcli dev wifi connection "$AP" password "raspberry"
+
+	if [$? -eq 0]; then
+		echo "Connection to $AP success"
+	else 
+		echo "Failed to connect to $AP"
+	fi
+}
+
+connection_check() {
+	if [ -f "/etc/wifi_connection" ]; then
+		if grep -q "$AP" "/etc/wifi-connection"; then
+			exit 0
+		else
+			first_con
+		fi
+	fi
+}
+
+connection_check
 
 case "$1" in
 	up)

--- a/tools/pi/scripts/AP.sh
+++ b/tools/pi/scripts/AP.sh
@@ -1,4 +1,23 @@
 !/usr/bin/bash
 #source $(t3x -T)
 
+#var set to AP SSID
+AP="RaspAP"
 
+AP_up() {}
+
+AP_down() {}
+
+
+case "$1" in
+	up)
+		# pull AP up
+		;;
+	down)
+		# pull AP down
+		;;
+	*)
+		# display command usage?
+		exit 1
+		;;
+esac

--- a/tools/pi/scripts/AP.sh
+++ b/tools/pi/scripts/AP.sh
@@ -1,0 +1,4 @@
+!/usr/bin/bash
+#source $(t3x -T)
+
+

--- a/tools/pi/scripts/AP.sh
+++ b/tools/pi/scripts/AP.sh
@@ -4,17 +4,26 @@
 #var set to AP SSID
 AP="RaspAP"
 
-AP_up() {}
+AP_up() {
+	nmcli connection up "$AP"
+	echo "Access Point '$AP' has been turned on"
+}
 
-AP_down() {}
+AP_down() {
+	nmcli connection down "$AP"
+	echo "Access Point '$AP' has been turned off"
+
+}
 
 
 case "$1" in
 	up)
 		# pull AP up
+		AP_up
 		;;
 	down)
 		# pull AP down
+		AP_down
 		;;
 	*)
 		# display command usage?

--- a/tools/pi/scripts/router.sh
+++ b/tools/pi/scripts/router.sh
@@ -1,5 +1,5 @@
-!/usr/bin/bash
-# source $(t3x -T)
+#!/usr/bin/bash
+source $(t3x -T)
 
 #think this may be needed..
 router_ip = "10.20.24.1"
@@ -17,6 +17,7 @@ enable_route() {
 	echo "Traffic to router is now: ENABLED"
 }
 
+
 case "$1" in
 	enable)
 		enable_route
@@ -30,5 +31,4 @@ case "$1" in
 esac
 
 #TODO
-# - adjust nft tables for enable/disable router..?
 # - check for table changes?

--- a/tools/pi/scripts/router.sh
+++ b/tools/pi/scripts/router.sh
@@ -1,0 +1,4 @@
+!/usr/bin/bash
+# source $(t3x -T)
+
+

--- a/tools/pi/scripts/router.sh
+++ b/tools/pi/scripts/router.sh
@@ -4,10 +4,18 @@
 #think this may be needed..
 router_ip = "10.20.24.1"
 
+disable_route() {
+	echo "disabling traffic to Router: $router_ip"
+	sudo nft add table inet filter
+	sudo nft add rule inet filter output drop 
+	echo "traffic to router is: DISABLED"
+}
 
-disable_route() {}
-
-enable_route() {}
+enable_route() {
+	echo "Enabling traffic to router: $router_ip"
+	sudo nft flush table inet filter
+	echo "Traffic to router is now: ENABLED"
+}
 
 case "$1" in
 	enable)
@@ -23,4 +31,4 @@ esac
 
 #TODO
 # - adjust nft tables for enable/disable router..?
-# - check for table changes
+# - check for table changes?

--- a/tools/pi/scripts/router.sh
+++ b/tools/pi/scripts/router.sh
@@ -1,4 +1,26 @@
 !/usr/bin/bash
 # source $(t3x -T)
 
+#think this may be needed..
+router_ip = "10.20.24.1"
 
+
+disable_route() {}
+
+enable_route() {}
+
+case "$1" in
+	enable)
+		enable_route
+		;;
+	disable)
+		disable_route
+		;;
+	*)
+		exit 1
+		;;
+esac
+
+#TODO
+# - adjust nft tables for enable/disable router..?
+# - check for table changes

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -1,7 +1,13 @@
 !/usr/bin/bash
 #source $(t3x -T)
 
-status_Router() {}
+status_Router() {
+	if sudo nft list ruleset | grep -q "drop"; then
+		echo "Router is currently: DISABLED"
+	else
+		echo "Router is currently: ENABLED"
+	fi
+}
 
 status_AP() {
 	interface = "wlan0" #this may change though....
@@ -37,8 +43,6 @@ case "$1" in
 esac
 
 #TODO
-# - fill the functions
-# - compare on and off for each function
 # - print usage?
 # - test on new pi
 # - test t3x compatability..

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -3,7 +3,25 @@
 
 status_Router() {}
 
-status_AP() {}
+status_AP() {
+	interface = "wlan0" #this may change though....
+	AP="RaspAP"
+	
+	echo "Status: "
+	if nmcli device show "$interface" &> /dev/null; then
+		
+		wifi_status=$(nmcli -t -f GENERAL.STATE device show "$interface" | awk -F: '{print $2}')
+		echo "$wifi_status"
+
+		if echo "$wifi_status" | grep -q "connected" ; then
+			echo "Raspberry AP is : CONNECTED" 
+		else
+			echo "Raspberry AP is : DISCONNECTED"
+		fi
+	else
+		echo "Connection $interface does not exist"
+	fi
+}
 
 #main
 case "$1" in 

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -13,10 +13,10 @@ status_AP() {
 		wifi_status=$(nmcli -t -f GENERAL.STATE device show "$interface" | awk -F: '{print $2}')
 		echo "$wifi_status"
 
-		if echo "$wifi_status" | grep -q "connected" ; then
-			echo "Raspberry AP is : CONNECTED" 
+		if echo "$wifi_status" | grep -q "disconnected" ; then
+			echo "Raspberry AP is : DISCONNECTED" 
 		else
-			echo "Raspberry AP is : DISCONNECTED"
+			echo "Raspberry AP is : CONNECTED"
 		fi
 	else
 		echo "Connection $interface does not exist"

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -1,4 +1,26 @@
 !/usr/bin/bash
 #source $(t3x -T)
 
+status_Router() {}
 
+status_AP() {}
+
+#main
+case "$1" in 
+	router)
+		status_Router
+		;;
+	ap)
+		status_AP
+		;;
+	*)
+		#usage?
+		;;
+esac
+
+#TODO
+# - fill the functions
+# - compare on and off for each function
+# - print usage?
+# - test on new pi
+# - test t3x compatability..

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/bash
 source $(t3x -T)
 
+require_command "lolcat"
+
 status_Router() {
 	if sudo nft list ruleset | grep -q "drop"; then
-		echo "Router is currently: DISABLED"
+		echo "Router is currently:"
+		echo " DISABLED" | lolcat
 	else
-		echo "Router is currently: ENABLED"
+		echo "Router is currently:"
+		echo " ENABLED" | lolcat
 	fi
 }
 
@@ -20,9 +24,11 @@ status_AP() {
 		echo "$wifi_status"
 
 		if echo "$wifi_status" | grep -q "disconnected" ; then
-			echo "Raspberry AP is : DISCONNECTED" 
+			echo "Raspberry AP is :"
+			echo " DISCONNECTED" | lolcat 
 		else
-			echo "Raspberry AP is : CONNECTED"
+			echo "Raspberry AP is :"
+			echo " CONNECTED" | lolcat
 		fi
 	else
 		echo "Connection $interface does not exist"

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -1,0 +1,4 @@
+!/usr/bin/bash
+#source $(t3x -T)
+
+

--- a/tools/pi/scripts/status.sh
+++ b/tools/pi/scripts/status.sh
@@ -1,5 +1,5 @@
-!/usr/bin/bash
-#source $(t3x -T)
+#!/usr/bin/bash
+source $(t3x -T)
 
 status_Router() {
 	if sudo nft list ruleset | grep -q "drop"; then
@@ -43,6 +43,5 @@ case "$1" in
 esac
 
 #TODO
-# - print usage?
-# - test on new pi
-# - test t3x compatability..
+# - build a help section?
+# - additional QC?


### PR DESCRIPTION
### The scripts
- AP.sh : built to turn on and off an Access Point on a raspberry pi network. This script checks to see if the Pi has already been connected before, and provides the information for first time connection.
- router.sh : similar to AP.sh, this turns on and off routing through the nftables which allows/prevents NAT thus limiting internet access.
- status.sh : provides the current status of the Access Point or Router based on request.

### Added Commands
t3x pi [status ap | status router | ap up/down | router enable/disable ]