### PR TITLE
lsof needed, even on slim

### DIFF
--- a/lib/packages.txt
+++ b/lib/packages.txt
@@ -11,3 +11,4 @@ vim
 tmux
 htop
 pv
+lsof


### PR DESCRIPTION
Found hard way that lsof should be hanging around for t3x.
Some of the slim (no-desktop) images don't have this by default.